### PR TITLE
install Python 2.7

### DIFF
--- a/post_install.sh
+++ b/post_install.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Install Python27
+env ASSUME_ALWAYS_YES=YES pkg install python2-2_3
+
 # Create symlinks for python
 ln -s /usr/local/bin/python2.7 /usr/local/bin/python2
 ln -s /usr/local/bin/python2.7 /usr/local/bin/python


### PR DESCRIPTION
Python 2.7 is missing from newer images (like 12.2).

At some point motionEye will support Python 3 (see https://github.com/ccrisan/motioneye/issues/1208 ); meanwhile, we need to install Python 2.7.