### PR TITLE
install mosquitto package

### DIFF
--- a/post_install.sh
+++ b/post_install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-# Install Python27
-env ASSUME_ALWAYS_YES=YES pkg install python2-2_3
+# Install Python 2.7 and Mosquitto (for mosquitto_pub)
+env ASSUME_ALWAYS_YES=YES pkg install python2 mosquitto
 
 # Create symlinks for python
 ln -s /usr/local/bin/python2.7 /usr/local/bin/python2


### PR DESCRIPTION
Also installed Mosquitto.
While not mandatory to make motionEye work, mosquitto_pub is often used to publish motion events.

In this commit I've also removed the specific version of the python2 package (I assume it can now work even for future releases of python2).